### PR TITLE
Correct coeff normalization wrt bin width

### DIFF
--- a/casper_library/pfb_coeff_gen_calc.m
+++ b/casper_library/pfb_coeff_gen_calc.m
@@ -48,7 +48,7 @@ if debug,
     coeff_vector = index;
 else
     windowval = transpose(window(WindowType, alltaps));
-    total_coeffs = windowval .* sinc(fwidth * ([0:alltaps-1]/(2^PFBSize)-TotalTaps/2));
+    total_coeffs = fwidth * windowval .* sinc(fwidth * ([0:alltaps-1]/(2^PFBSize)-TotalTaps/2));
     coeff_vector = total_coeffs(index);
 end
 % end


### PR DESCRIPTION
Correct the normalization of coefficients when the scaling of the bin width is modified.
If you look at the pair 201 in https://en.wikipedia.org/wiki/Fourier_transform#Square-integrable_functions,_one-dimensional ,
you will notice that shrinking that rect function (a = 1/fwidth > 1), leads to a multiplication by fwidth inside and outside the sinc.
If you don't do both, it leads to a gain in the PFB response.